### PR TITLE
Avoid header overlapping content.

### DIFF
--- a/CV.html
+++ b/CV.html
@@ -7,9 +7,9 @@
 
 
 
-<div id="fixedheader"><h1>Joseph M. Thompson</h1>
-
-
+<div id="fixedheader">
+<img src="JT headshot.jpg" width="300" height="200">
+<h1>Joseph M. Thompson</h1>
 <h3>Doctoral Candidate<br>
 Corcoran Department of History<br>
 University of Virginia<br>
@@ -22,9 +22,6 @@ University of Virginia<br>
 
 <body>
 
-<center>
-<img src="JT headshot.jpg" width="300" height="200">
-</center>
 
 
 

--- a/style.css
+++ b/style.css
@@ -25,11 +25,9 @@ body {
   max-width: 700px;
 
   padding: 20px;
-  margin: auto;
-  margin-top: 3em;
   margin-bottom: 3em;
 
-padding-left: 20%;
+  padding-left: 340px;
 
 
 
@@ -41,10 +39,7 @@ div#fixedheader {
 	position:fixed;
 	top:20px;
 	left:30px;
-	width:20%;
-  
-
-min-width: 238px;
+  width: 300px;
   text-align: left;
 
 	background:transparent;


### PR DESCRIPTION
At smaller screen widths, the header would overlap the page content,
because it's a fixed position. This change avoides that overlap by:
- Setting the header at a fixed width;
- Removing the `auto` margin on the body (and thus removing the page
  centering);
- Adding left padding to the `body` element with a value slightly wider
  than the width of the fixed header.
